### PR TITLE
Decrease minSdkVersion to 17

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.mindinventory.placepicker"
-        minSdkVersion 19
+        minSdkVersion 17
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/vanillaplacepicker/build.gradle
+++ b/vanillaplacepicker/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 17
         targetSdkVersion 28
         versionCode 4
         versionName "0.0.4"


### PR DESCRIPTION
The project where I'm planning to use this lib requires at least `Android 4.2` and I couldn't find any issue to make this project backwards compatible up to `SDK 17`.

_Disclaimer: I know the ideal case would be to increase it 🤦‍♂_ 